### PR TITLE
Fix build break on Cygwin.

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -284,9 +284,9 @@ ADD_EXECUTABLE(madeline2 ${SOURCES} )
 # Link target:
 #
 TARGET_LINK_LIBRARIES(madeline2 
+	unzip
 	${requiredLibs} 
 	${libssl} 
-	unzip 
 	${PANGO_LINK_FLAGS}
 	${PANGOFT2_LINK_FLAGS} 
 	${LASI_LINK_FLAGS}


### PR DESCRIPTION
Required libraries are linked too early to provide functions for `3rdParty/unzip/unzip.c`.  It should be linked earlier than zlib.

(update) I have modified the commit to fix my address, sorry.